### PR TITLE
Add terraform support for GKEBackup channel resources.

### DIFF
--- a/mmv1/products/gkebackup/BackupChannel.yaml
+++ b/mmv1/products/gkebackup/BackupChannel.yaml
@@ -1,0 +1,116 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'BackupChannel'
+description: |
+  Represents a Backup Channel instance.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke'
+  api: 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/reference/rest/v1/projects.locations.backupChannels'
+docs:
+min_version: beta
+base_url: 'projects/{{project}}/locations/{{location}}/backupChannels'
+create_url: 'projects/{{project}}/locations/{{location}}/backupChannels?backupChannelId={{name}}'
+update_verb: 'PATCH'
+update_mask: true
+timeouts:
+  insert_minutes: 5
+  update_minutes: 5
+  delete_minutes: 5
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: true
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_attribute: 'name'
+  base_url: 'projects/{{project}}/locations/{{location}}/backupChannels/{{name}}'
+  example_config_body: 'templates/terraform/iam/iam_attributes.go.tmpl'
+  import_format:
+    - 'projects/{{project}}/locations/{{location}}/backupChannels/{{name}}'
+    - '{{name}}'
+custom_code:
+examples:
+  - name: 'gkebackup_backupchannel_basic'
+    primary_resource_id: 'basic'
+    primary_resource_name: 'fmt.Sprintf("tf-test-basic-channel%s", context["random_suffix"])'
+    vars:
+      name: 'basic-channel'
+      destination_project: 'projects/24240755850'
+    test_vars_overrides:
+      'destination_project': '"projects/24240755850"'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+    min_version: 'beta'
+parameters:
+  - name: 'location'
+    type: String
+    description: |
+      The region of the Backup Channel.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      The full name of the BackupChannel Resource.
+    required: true
+    immutable: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.tmpl'
+  - name: 'uid'
+    type: String
+    description: |
+      Server generated, unique identifier of UUID format.
+    output: true
+  - name: 'destinationProject'
+    type: String
+    description: |
+      The project where Backups are allowed to be stored.
+      The format is `projects/{project}`.
+      {project} can only be a project number.
+    required: true
+    immutable: true
+  - name: 'description'
+    type: String
+    description: |
+      User specified descriptive string for this BackupChannel.
+  - name: 'labels'
+    type: KeyValueLabels
+    description: |
+      Description: A set of custom labels supplied by the user.
+      A list of key->value pairs.
+      Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+  - name: 'etag'
+    type: String
+    description: |
+      etag is used for optimistic concurrency control as a way to help prevent simultaneous
+      updates of a backup channel from overwriting each other. It is strongly suggested that
+      systems make use of the 'etag' in the read-modify-write cycle to perform BackupChannel updates
+      in order to avoid race conditions: An etag is returned in the response to backupChannels.get,
+      and systems are expected to put that etag in the request to backupChannels.patch or
+      backupChannels.delete to ensure that their change will be applied to the same version of the resource.
+    output: true
+  - name: 'destinationProjectId'
+    type: String
+    description: |
+      The project_id where Backups are allowed to be stored.
+      Example Project ID: "my-project-id".
+    output: true

--- a/mmv1/products/gkebackup/BackupChannel.yaml
+++ b/mmv1/products/gkebackup/BackupChannel.yaml
@@ -14,7 +14,10 @@
 ---
 name: 'BackupChannel'
 description: |
-  Represents a Backup Channel instance.
+  A BackupChannel imposes constraints on where clusters can be backed up.
+  The BackupChannel should be in the same project and region
+  as the cluster being backed up.
+  The backup can be created only in destination_project.
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke'

--- a/mmv1/products/gkebackup/BackupChannel.yaml
+++ b/mmv1/products/gkebackup/BackupChannel.yaml
@@ -23,7 +23,6 @@ references:
     'Official Documentation': 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke'
   api: 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/reference/rest/v1/projects.locations.backupChannels'
 docs:
-min_version: beta
 base_url: 'projects/{{project}}/locations/{{location}}/backupChannels'
 create_url: 'projects/{{project}}/locations/{{location}}/backupChannels?backupChannelId={{name}}'
 update_verb: 'PATCH'
@@ -60,7 +59,6 @@ examples:
       'destination_project': '"projects/24240755850"'
     test_env_vars:
       project: 'PROJECT_NAME'
-    min_version: 'beta'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/gkebackup/BackupChannel.yaml
+++ b/mmv1/products/gkebackup/BackupChannel.yaml
@@ -39,14 +39,6 @@ async:
     base_url: '{{op_id}}'
   result:
     resource_inside_response: true
-iam_policy:
-  method_name_separator: ':'
-  parent_resource_attribute: 'name'
-  base_url: 'projects/{{project}}/locations/{{location}}/backupChannels/{{name}}'
-  example_config_body: 'templates/terraform/iam/iam_attributes.go.tmpl'
-  import_format:
-    - 'projects/{{project}}/locations/{{location}}/backupChannels/{{name}}'
-    - '{{name}}'
 custom_code:
 examples:
   - name: 'gkebackup_backupchannel_basic'

--- a/mmv1/products/gkebackup/RestoreChannel.yaml
+++ b/mmv1/products/gkebackup/RestoreChannel.yaml
@@ -14,7 +14,10 @@
 ---
 name: 'RestoreChannel'
 description: |
-  Represents a Restore Channel instance.
+  A RestoreChannel imposes constraints on where backups can be restored.
+  The RestoreChannel should be in the same project and region
+  as the backups. The backups can only be restored in the
+  destination_project.
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke'

--- a/mmv1/products/gkebackup/RestoreChannel.yaml
+++ b/mmv1/products/gkebackup/RestoreChannel.yaml
@@ -39,14 +39,6 @@ async:
     base_url: '{{op_id}}'
   result:
     resource_inside_response: true
-iam_policy:
-  method_name_separator: ':'
-  parent_resource_attribute: 'name'
-  base_url: 'projects/{{project}}/locations/{{location}}/restoreChannels/{{name}}'
-  example_config_body: 'templates/terraform/iam/iam_attributes.go.tmpl'
-  import_format:
-    - 'projects/{{project}}/locations/{{location}}/restoreChannels/{{name}}'
-    - '{{name}}'
 custom_code:
 examples:
   - name: 'gkebackup_restorechannel_basic'

--- a/mmv1/products/gkebackup/RestoreChannel.yaml
+++ b/mmv1/products/gkebackup/RestoreChannel.yaml
@@ -23,7 +23,6 @@ references:
     'Official Documentation': 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke'
   api: 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/reference/rest/v1/projects.locations.restoreChannels'
 docs:
-min_version: beta
 base_url: 'projects/{{project}}/locations/{{location}}/restoreChannels'
 create_url: 'projects/{{project}}/locations/{{location}}/restoreChannels?restoreChannelId={{name}}'
 update_verb: 'PATCH'
@@ -60,7 +59,6 @@ examples:
       'destination_project': '"projects/24240755850"'
     test_env_vars:
       project: 'PROJECT_NAME'
-    min_version: 'beta'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/gkebackup/RestoreChannel.yaml
+++ b/mmv1/products/gkebackup/RestoreChannel.yaml
@@ -1,0 +1,116 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RestoreChannel'
+description: |
+  Represents a Restore Channel instance.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke'
+  api: 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/reference/rest/v1/projects.locations.restoreChannels'
+docs:
+min_version: beta
+base_url: 'projects/{{project}}/locations/{{location}}/restoreChannels'
+create_url: 'projects/{{project}}/locations/{{location}}/restoreChannels?restoreChannelId={{name}}'
+update_verb: 'PATCH'
+update_mask: true
+timeouts:
+  insert_minutes: 5
+  update_minutes: 5
+  delete_minutes: 5
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: true
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_attribute: 'name'
+  base_url: 'projects/{{project}}/locations/{{location}}/restoreChannels/{{name}}'
+  example_config_body: 'templates/terraform/iam/iam_attributes.go.tmpl'
+  import_format:
+    - 'projects/{{project}}/locations/{{location}}/restoreChannels/{{name}}'
+    - '{{name}}'
+custom_code:
+examples:
+  - name: 'gkebackup_restorechannel_basic'
+    primary_resource_id: 'basic'
+    primary_resource_name: 'fmt.Sprintf("tf-test-basic-channel%s", context["random_suffix"])'
+    vars:
+      name: 'basic-channel'
+      destination_project: 'projects/24240755850'
+    test_vars_overrides:
+      'destination_project': '"projects/24240755850"'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+    min_version: 'beta'
+parameters:
+  - name: 'location'
+    type: String
+    description: |
+      The region of the Restore Channel.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      The full name of the RestoreChannel Resource.
+    required: true
+    immutable: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.tmpl'
+  - name: 'uid'
+    type: String
+    description: |
+      Server generated, unique identifier of UUID format.
+    output: true
+  - name: 'destinationProject'
+    type: String
+    description: |
+      The project where Backups will be restored.
+      The format is `projects/{project}`.
+      {project} can only be a project number.
+    required: true
+    immutable: true
+  - name: 'description'
+    type: String
+    description: |
+      User specified descriptive string for this RestoreChannel.
+  - name: 'labels'
+    type: KeyValueLabels
+    description: |
+      Description: A set of custom labels supplied by the user.
+      A list of key->value pairs.
+      Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+  - name: 'etag'
+    type: String
+    description: |
+      etag is used for optimistic concurrency control as a way to help prevent simultaneous
+      updates of a restore channel from overwriting each other. It is strongly suggested that
+      systems make use of the 'etag' in the read-modify-write cycle to perform RestoreChannel updates
+      in order to avoid race conditions: An etag is returned in the response to restoreChannels.get,
+      and systems are expected to put that etag in the request to restoreChannels.patch or
+      restoreChannels.delete to ensure that their change will be applied to the same version of the resource.
+    output: true
+  - name: 'destinationProjectId'
+    type: String
+    description: |
+      The project_id where Backups will be restored.
+      Example Project ID: "my-project-id".
+    output: true

--- a/mmv1/templates/terraform/examples/gkebackup_backupchannel_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupchannel_basic.tf.tmpl
@@ -3,5 +3,6 @@ resource "google_gke_backup_backup_channel" "basic" {
 
   name = "{{index $.Vars "name"}}"
   location = "us-central1"
+  description = "{{index $.Vars "description"}}"
   destination_project = "{{index $.Vars "destination_project"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_backupchannel_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupchannel_basic.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_gke_backup_backup_channel" "basic" {
-  provider = google-beta
-
   name = "{{index $.Vars "name"}}"
   location = "us-central1"
   description = "{{index $.Vars "description"}}"

--- a/mmv1/templates/terraform/examples/gkebackup_backupchannel_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupchannel_basic.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_gke_backup_backup_channel" "basic" {
+  provider = google-beta
+
+  name = "{{index $.Vars "name"}}"
+  location = "us-central1"
+  destination_project = "{{index $.Vars "destination_project"}}"
+}

--- a/mmv1/templates/terraform/examples/gkebackup_backupchannel_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupchannel_basic.tf.tmpl
@@ -3,4 +3,5 @@ resource "google_gke_backup_backup_channel" "basic" {
   location = "us-central1"
   description = "{{index $.Vars "description"}}"
   destination_project = "{{index $.Vars "destination_project"}}"
+  labels = { "key": "some-value" }
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restorechannel_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restorechannel_basic.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_gke_backup_restore_channel" "basic" {
+  provider = google-beta
+
+  name = "{{index $.Vars "name"}}"
+  location = "us-central1"
+  destination_project = "{{index $.Vars "destination_project"}}"
+}

--- a/mmv1/templates/terraform/examples/gkebackup_restorechannel_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restorechannel_basic.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_gke_backup_restore_channel" "basic" {
-  provider = google-beta
-
   name = "{{index $.Vars "name"}}"
   location = "us-central1"
   description = "{{index $.Vars "description"}}"

--- a/mmv1/templates/terraform/examples/gkebackup_restorechannel_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restorechannel_basic.tf.tmpl
@@ -3,4 +3,5 @@ resource "google_gke_backup_restore_channel" "basic" {
   location = "us-central1"
   description = "{{index $.Vars "description"}}"
   destination_project = "{{index $.Vars "destination_project"}}"
+  labels = { "key": "some-value" }
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restorechannel_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restorechannel_basic.tf.tmpl
@@ -3,5 +3,6 @@ resource "google_gke_backup_restore_channel" "basic" {
 
   name = "{{index $.Vars "name"}}"
   location = "us-central1"
+  description = "{{index $.Vars "description"}}"
   destination_project = "{{index $.Vars "destination_project"}}"
 }

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
@@ -13,20 +13,21 @@ func TestAccGKEBackupBackupChannel_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project":       envvar.GetTestProjectFromEnv(),
-		"random_suffix": acctest.RandString(t, 10),
+		"project":             envvar.GetTestProjectFromEnv(),
+		"destination_project": "projects/24240755850",
+		"random_suffix":       acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckGKEBackupBackupChannelDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGKEBackupBackupChannel_basic(context),
 			},
 			{
-				ResourceName:            "google_gke_backup_backup_channel.backupchannel",
+				ResourceName:            "google_gke_backup_backup_channel.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels"},
@@ -37,14 +38,11 @@ func TestAccGKEBackupBackupChannel_update(t *testing.T) {
 
 func testAccGKEBackupBackupChannel_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_gke_backup_backup_channel" "backupchannel" {
-  name = "tf-test-testbackupchannel%{random_suffix}"
+resource "google_gke_backup_backup_channel" "basic" {
+  name = "tf-test-basic-channel%{random_suffix}"
   location = "us-central1"
-  destination_project = "projects/24240755850"
-  description = "some-description"
-  labels = {
-    "some-key-1": "some-value-1"
-  }
+  description = ""
+  destination_project = "%{destination_project}"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
@@ -26,7 +26,7 @@ func TestAccGKEBackupBackupChannel_update(t *testing.T) {
 				Config: testAccGKEBackupBackupChannel_basic(context),
 			},
 			{
-				ResourceName:            "google_gke_backup_backup_channel.basic",
+				ResourceName:            "google_gke_backup_backup_channel.backupchannel",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels"},
@@ -37,7 +37,7 @@ func TestAccGKEBackupBackupChannel_update(t *testing.T) {
 
 func testAccGKEBackupBackupChannel_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_gke_backup_backup_channel" "basic" {
+resource "google_gke_backup_backup_channel" "backupchannel" {
   name = "tf-test-testbackupchannel%{random_suffix}"
   location = "us-central1"
   destination_project = "projects/24240755850"

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
@@ -43,6 +43,7 @@ resource "google_gke_backup_backup_channel" "basic" {
   location = "us-central1"
   description = ""
   destination_project = "%{destination_project}"
+  labels = { "key": "some-value" }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
@@ -1,0 +1,49 @@
+package gkebackup_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGKEBackupBackupChannel_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckGKEBackupBackupChannelDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEBackupBackupChannel_basic(context),
+			},
+			{
+				ResourceName:            "google_gke_backup_backup_channel.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccGKEBackupBackupChannel_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gke_backup_backup_channel" "basic" {
+  name = "tf-test-testbackupchannel%{random_suffix}"
+  location = "us-central1"
+  destination_project = "projects/24240755850"
+  labels = {
+    "some-key-1": "some-value-1"
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
@@ -14,7 +14,7 @@ func TestAccGKEBackupBackupChannel_update(t *testing.T) {
 
 	context := map[string]interface{}{
 		"project":             envvar.GetTestProjectFromEnv(),
-		"destination_project": "projects/24240755850",
+		"destination_project": "projects/331279474308",
 		"random_suffix":       acctest.RandString(t, 10),
 	}
 

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_channel_test.go.tmpl
@@ -41,6 +41,7 @@ resource "google_gke_backup_backup_channel" "basic" {
   name = "tf-test-testbackupchannel%{random_suffix}"
   location = "us-central1"
   destination_project = "projects/24240755850"
+  description = "some-description"
   labels = {
     "some-key-1": "some-value-1"
   }

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
@@ -43,6 +43,7 @@ resource "google_gke_backup_restore_channel" "basic" {
   location = "us-central1"
   description = ""
   destination_project = "%{destination_project}"
+  labels = { "key": "some-value" }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
@@ -13,20 +13,21 @@ func TestAccGKEBackupRestoreChannel_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project":       envvar.GetTestProjectFromEnv(),
-		"random_suffix": acctest.RandString(t, 10),
+		"project":             envvar.GetTestProjectFromEnv(),
+		"destination_project": "projects/24240755850",
+		"random_suffix":       acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckGKEBackupRestoreChannelDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGKEBackupRestoreChannel_basic(context),
 			},
 			{
-				ResourceName:            "google_gke_backup_restore_channel.restorechannel",
+				ResourceName:            "google_gke_backup_restore_channel.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels"},
@@ -37,14 +38,11 @@ func TestAccGKEBackupRestoreChannel_update(t *testing.T) {
 
 func testAccGKEBackupRestoreChannel_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_gke_backup_restore_channel" "restorechannel" {
-  name = "tf-test-testrestorechannel%{random_suffix}"
+resource "google_gke_backup_restore_channel" "basic" {
+  name = "tf-test-basic-channel%{random_suffix}"
   location = "us-central1"
-  destination_project = "projects/24240755850"
-  description = "some-description"
-  labels = {
-    "some-key-1": "some-value-1"
-  }
+  description = ""
+  destination_project = "%{destination_project}"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
@@ -14,7 +14,7 @@ func TestAccGKEBackupRestoreChannel_update(t *testing.T) {
 
 	context := map[string]interface{}{
 		"project":             envvar.GetTestProjectFromEnv(),
-		"destination_project": "projects/24240755850",
+		"destination_project": "projects/331279474308",
 		"random_suffix":       acctest.RandString(t, 10),
 	}
 

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
@@ -1,0 +1,49 @@
+package gkebackup_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGKEBackupRestoreChannel_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckGKEBackupRestoreChannelDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEBackupRestoreChannel_basic(context),
+			},
+			{
+				ResourceName:            "google_gke_backup_restore_channel.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccGKEBackupRestoreChannel_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gke_backup_restore_channel" "basic" {
+  name = "tf-test-testrestorechannel%{random_suffix}"
+  location = "us-central1"
+  destination_project = "projects/24240755850"
+  labels = {
+    "some-key-1": "some-value-1"
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
@@ -41,6 +41,7 @@ resource "google_gke_backup_restore_channel" "basic" {
   name = "tf-test-testrestorechannel%{random_suffix}"
   location = "us-central1"
   destination_project = "projects/24240755850"
+  description = "some-description"
   labels = {
     "some-key-1": "some-value-1"
   }

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_channel_test.go.tmpl
@@ -26,7 +26,7 @@ func TestAccGKEBackupRestoreChannel_update(t *testing.T) {
 				Config: testAccGKEBackupRestoreChannel_basic(context),
 			},
 			{
-				ResourceName:            "google_gke_backup_restore_channel.basic",
+				ResourceName:            "google_gke_backup_restore_channel.restorechannel",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels"},
@@ -37,7 +37,7 @@ func TestAccGKEBackupRestoreChannel_update(t *testing.T) {
 
 func testAccGKEBackupRestoreChannel_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_gke_backup_restore_channel" "basic" {
+resource "google_gke_backup_restore_channel" "restorechannel" {
   name = "tf-test-testrestorechannel%{random_suffix}"
   location = "us-central1"
   destination_project = "projects/24240755850"


### PR DESCRIPTION
Add terraform support for backup and restore channels.

All test cases are passing locally.

Note: We are using project number of `gkebackup-test` for destination project in case of channel creation.
